### PR TITLE
Use Raleway font for headings and body

### DIFF
--- a/intervarsitychapter/css/child-theme.css
+++ b/intervarsitychapter/css/child-theme.css
@@ -7176,20 +7176,20 @@ a.skip-link {
 
 h2 {
   color: #0a214f;
-  font-family: 'Lato','Trebuchet MS', Arial, Helvetica, sans-serif;
   font-size: 1.4rem; }
 
 h1 {
   color: #0076c0;
-  font-family: 'Lato','Trebuchet MS', Arial, Helvetica, sans-serif;
   font-size: 3rem;
   border-bottom: solid 1px #0076c0; }
 
 body {
   font-size: 14px;
-  font-family: 'Lato','Trebuchet MS', Arial, Helvetica, sans-serif;
   line-height: 1.5em;
   color: #475e7b; }
+
+body, h1, h2 {
+  font-family: 'Raleway', 'Trebuchet MS', Arial, Helvetica, sans-serif; }
 
 a {
   color: #0076c0; }

--- a/intervarsitychapter/header.php
+++ b/intervarsitychapter/header.php
@@ -15,7 +15,7 @@
 <meta name="mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-title" content="<?php bloginfo('name'); ?> - <?php bloginfo('description'); ?>">
-<link href="https://fonts.googleapis.com/css?family=Lato:300,400,700" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css?family=Raleway:300,400,500,700" rel="stylesheet">
 <link rel="profile" href="http://gmpg.org/xfn/11">
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>">
 <?php wp_head(); ?>

--- a/intervarsitychapter/sass/theme/_child_theme.scss
+++ b/intervarsitychapter/sass/theme/_child_theme.scss
@@ -2,21 +2,22 @@
 //START: quick hack for a demo. Add named color vars to the theme var file, then replace.
 h2{
   color: #0a214f;
-  font-family: 'Lato','Trebuchet MS', Arial, Helvetica, sans-serif;
   font-size: 1.4rem;
 }
 
 h1{
   color: #0076c0;
-  font-family: 'Lato','Trebuchet MS', Arial, Helvetica, sans-serif;
   font-size: 3rem;
   border-bottom: solid 1px #0076c0;
 }
 body{
   font-size: 14px;
-  font-family: 'Lato','Trebuchet MS', Arial, Helvetica, sans-serif;
 line-height: 1.5em;
 color: #475e7b;
+}
+
+body, h1, h2 {
+  font-family: 'Raleway', 'Trebuchet MS', Arial, Helvetica, sans-serif;
 }
 
 a{


### PR DESCRIPTION
This PR updates the theme to use the Raleway font for the page body and headings, per #10.